### PR TITLE
feat: add default 10 seconds timeout in all requests

### DIFF
--- a/openload/openload.py
+++ b/openload/openload.py
@@ -14,13 +14,13 @@ class OpenLoad(object):
     api_base_url = 'https://api.openload.co/{api_version}/'
     api_version = '1'
 
-    def __init__(self, api_login, api_key, timeout=10.0):
+    def __init__(self, api_login, api_key, timeout=30.0):
         """Initializes OpenLoad instance with given parameters and formats api base url.
 
         Args:
             api_login (str): API Login found in openload.co
             api_key (str): API Key found in openload.co
-            timeout (float): timeout in seconds for all requests
+            timeout (float): timeout in seconds for all requests defaults to 30 seconds.
 
         Returns:
             None

--- a/openload/openload.py
+++ b/openload/openload.py
@@ -14,17 +14,20 @@ class OpenLoad(object):
     api_base_url = 'https://api.openload.co/{api_version}/'
     api_version = '1'
 
-    def __init__(self, api_login, api_key):
+    def __init__(self, api_login, api_key, timeout=10.0):
         """Initializes OpenLoad instance with given parameters and formats api base url.
 
         Args:
             api_login (str): API Login found in openload.co
             api_key (str): API Key found in openload.co
+            timeout (float): timeout in seconds for all requests
 
         Returns:
             None
 
         """
+        self.timeout = timeout
+
         self.login = api_login
         self.key = api_key
         self.api_url = self.api_base_url.format(api_version=self.api_version)
@@ -89,7 +92,7 @@ class OpenLoad(object):
 
         params.update({'login': self.login, 'key': self.key})
 
-        response_json = requests.get(self.api_url + url, params).json()
+        response_json = requests.get(self.api_url + url, params, timeout=self.timeout).json()
 
         return self._process_response(response_json)
 
@@ -266,7 +269,7 @@ class OpenLoad(object):
             })
 
             headers = {"Content-Type": data.content_type}
-            response_json = requests.post(upload_url, data=data, headers=headers).json()
+            response_json = requests.post(upload_url, data=data, headers=headers, timeout=self.timeout).json()
 
         self._check_status(response_json)
         return response_json['result']

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with copen(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='pyopenload',
-    version='0.7',
+    version='0.8',
     description='Python wrapper for openload.co API',
     long_description=long_description,
     url='https://github.com/mohan3d/PyOpenload',


### PR DESCRIPTION
Add default timeout 30 seconds for all outgoing requests, since some requests stuck with no response and no exception raised.